### PR TITLE
Add session management

### DIFF
--- a/lib/ipa/client.rb
+++ b/lib/ipa/client.rb
@@ -34,7 +34,7 @@ module IPA
       # Initiate the security context
       token = gssapi.init_context
 
-      login_uri = URI.parse("https://#{host}/ipa/json")
+      login_uri = URI.parse("https://#{host}/ipa/session/login_kerberos")
       login_request = { :method => "ping", :params => [[],{}] }
       login_headers = {'referer' => "https://#{uri.host}/ipa/ui/index.html", 'Content-Type' => 'application/json', 'Accept' => 'application/json', 'Authorization' => "Negotiate #{Base64.strict_encode64(token)}"}
 


### PR DESCRIPTION
Re-using the same gssapi security context with every request causes
issues with the authentication towards the IPA server. This
implementation will authenticate once and then use the session endpoint
to continue the authentication.

Any request that is successfully authenticated will set a session cookie
in the response that is valid in the /ipa/session/json endpoint.
HTTPClient automatically handles the cookies within the object.

In IPA 4.4 the correct way of authenticating is to issue a request to
the /ipa/session/login_kerberos endpoint, this is not available in 4.2.0
though.